### PR TITLE
feat: basic trim video

### DIFF
--- a/features/compression/components/video-metadata-display.tsx
+++ b/features/compression/components/video-metadata-display.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { secondsToTimestamp } from "../lib/seconds-to-timestamp";
+import { timestampToSeconds } from "../lib/timestamp-to-seconds";
 
 interface VideoMetadata {
   duration?: number;
@@ -12,6 +13,9 @@ interface COptions {
   scale?: number;
   width?: number;
   height?: number;
+  /** hh:mm:ss */
+  trimStart?: string;
+  trimEnd?: string;
 }
 
 interface VideoMetadataDisplayProps {
@@ -25,11 +29,35 @@ export function VideoMetadataDisplay({
   cOptions,
   estimatedSize,
 }: VideoMetadataDisplayProps) {
+
+  const calculateVideoDuration = (duration: number) => {
+    if (cOptions.trimStart && cOptions.trimEnd) {
+      return secondsToTimestamp(
+        timestampToSeconds(cOptions.trimEnd) -
+          timestampToSeconds(cOptions.trimStart)
+      );
+    }
+    if (cOptions.trimEnd) {
+      return cOptions.trimEnd;
+    }
+    if (cOptions.trimStart) {
+      return secondsToTimestamp(
+        duration - timestampToSeconds(cOptions.trimStart)
+      );
+    }
+    return secondsToTimestamp(duration);
+  }
+
+  const duration = useMemo(
+    () => videoMetadata?.duration && calculateVideoDuration(videoMetadata.duration), 
+    [videoMetadata.duration, cOptions.trimStart, cOptions.trimEnd]
+  );
+
   return (
     <div className="flex flex-col gap-1">
-      {videoMetadata?.duration && (
+      {duration && (
         <p className="text-sm text-foreground">
-          <b>Video Duration:</b> {secondsToTimestamp(videoMetadata.duration)}
+          <b>Video Duration:</b> {duration}
         </p>
       )}
       {videoMetadata?.width && videoMetadata?.height && (

--- a/features/compression/components/video-metadata-display.tsx
+++ b/features/compression/components/video-metadata-display.tsx
@@ -30,6 +30,11 @@ export function VideoMetadataDisplay({
   estimatedSize,
 }: VideoMetadataDisplayProps) {
 
+  /**
+   * Calculates the total duration of the video based on the trim start and end options.
+   *
+   * @param duration The number of seconds
+   */
   const calculateVideoDuration = (duration: number) => {
     if (cOptions.trimStart && cOptions.trimEnd) {
       return secondsToTimestamp(

--- a/features/compression/components/video-settings.tsx
+++ b/features/compression/components/video-settings.tsx
@@ -175,6 +175,12 @@ export function VideoSettings({
         ...cOptions,
         trimEnd: secondsToTimestamp(videoMetadata.duration),
       });
+    } else if (!trimVideo) {
+      onOptionsChange({
+        ...cOptions,
+        trimStart: undefined,
+        trimEnd: undefined,
+      });
     }
   }, [trimVideo, videoMetadata]);
 

--- a/features/compression/components/video-settings.tsx
+++ b/features/compression/components/video-settings.tsx
@@ -23,6 +23,7 @@ import {
 import { useEffect, useState } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { VideoMetadata } from "../lib/get-video-metadata";
+import { secondsToTimestamp } from "../lib/seconds-to-timestamp";
 
 export type CompressionOptions = {
   quality: number;
@@ -34,6 +35,8 @@ export type CompressionOptions = {
   removeAudio?: boolean;
   generatePreview?: boolean;
   previewDuration?: number;
+  trimStart?: string;
+  trimEnd?: string;
 };
 
 type BasicPresets = "basic" | "super" | "ultra" | "cooked";
@@ -151,6 +154,7 @@ export function VideoSettings({
   const [activeTab, setActiveTab] = useState<TabOptions>("basic");
   const [basicPreset, setBasicPreset] = useState<BasicPresets>("super");
   const [maintainAspectRatio, setMaintainAspectRatio] = useState(true);
+  const [trimVideo, setTrimVideo] = useState(false);
 
   useEffect(() => {
     if (videoMetadata && activeTab === "super") {
@@ -164,6 +168,15 @@ export function VideoSettings({
       });
     }
   }, [videoMetadata, activeTab]);
+
+  useEffect(() => {
+    if (trimVideo && videoMetadata?.duration) {
+      onOptionsChange({
+        ...cOptions,
+        trimEnd: secondsToTimestamp(videoMetadata.duration),
+      });
+    }
+  }, [trimVideo, videoMetadata]);
 
   const handleQualityChange = (value: number) => {
     onOptionsChange({
@@ -227,6 +240,14 @@ export function VideoSettings({
       removeAudio: value,
     });
   };
+
+  const handleTrimVideoChange = (value: boolean) => {
+    setTrimVideo(value);
+    onOptionsChange({
+      ...cOptions,
+      trimStart: value ? "00:00:00" : undefined,
+    });
+  }
 
   const handlePreviewDurationChange = (value: number) => {
     onOptionsChange({
@@ -519,7 +540,7 @@ export function VideoSettings({
               <div className="grid grid-cols-2 gap-2">
                 <div>
                   <Label className="text-base mb-2 block" htmlFor="width">
-                    Width (px) 
+                    Width (px)
                   </Label>
                   <Input
                     disabled={isDisabled}
@@ -547,7 +568,7 @@ export function VideoSettings({
                   />
                 </div>
               </div>
-              
+
               <div className="flex items-center space-x-2">
                 <Checkbox
                   id="ratio"
@@ -606,6 +627,59 @@ export function VideoSettings({
               <p className="text-sm text-gray-500">
                 Frames per second. Lower FPS will result in smaller file size
               </p>
+            </div>
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="trimVideo"
+                  checked={trimVideo}
+                  disabled={isDisabled}
+                  onCheckedChange={(checked) => handleTrimVideoChange(!!checked)}
+                />
+                <label
+                  htmlFor="trimVideo"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  Trim Video
+                </label>
+              </div>
+            {trimVideo && (
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <Label className="text-base font-bold" htmlFor="trimStart">
+                    Trim Start (hh:mm:ss)
+                  </Label>
+                  <Input
+                    disabled={isDisabled}
+                    onChange={(e) =>
+                      onOptionsChange({
+                        ...cOptions,
+                        trimStart: e.target.value,
+                      })
+                    }
+                    value={cOptions.trimStart}
+                    type="string"
+                    id="trimStart"
+                  />
+                </div>
+                <div>
+                  <Label className="text-base font-bold" htmlFor="trimEnd">
+                    Trim End (hh:mm:ss)
+                  </Label>
+                  <Input
+                    disabled={isDisabled}
+                    onChange={(e) =>
+                      onOptionsChange({
+                        ...cOptions,
+                        trimEnd: e.target.value,
+                      })
+                    }
+                    value={cOptions.trimEnd}
+                    type="string"
+                    id="trimEnd"
+                  />
+                </div>
+              </div>)}
             </div>
             <div className="flex flex-col gap-2">
               <h3 className="text-base font-bold">Audio</h3>

--- a/features/compression/components/video-settings.tsx
+++ b/features/compression/components/video-settings.tsx
@@ -20,7 +20,7 @@ import {
   LucideIcon,
   RocketIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { VideoMetadata } from "../lib/get-video-metadata";
 import { secondsToTimestamp } from "../lib/seconds-to-timestamp";
@@ -218,6 +218,30 @@ export function VideoSettings({
       height: value,
       width: maintainAspectRatio ? Math.round(value * (videoMetadata?.width || 1920) / (videoMetadata?.height || 1080)) : cOptions.width,
     });
+  }
+
+  const trimInputError = useCallback(() => {
+    if (trimVideo && !cOptions.trimStart?.match(/^\d+:[0-5]\d:[0-5]\d$/)) {
+      return "Trim start must be in format hh:mm:ss";
+    } else if (trimVideo && cOptions.trimEnd && !cOptions.trimEnd.match(/^\d+:[0-5]\d:[0-5]\d$/)) {
+      return "Trim end must be in format hh:mm:ss";
+    } else {
+      return "";
+    }
+  }, [trimVideo, cOptions.trimStart, cOptions.trimEnd])
+
+  const handleTrimStartChange = (duration: string) => {
+      onOptionsChange({
+        ...cOptions,
+        trimStart: duration,
+      })
+  }
+
+  const handleTrimEndChange = (duration: string) => {
+    onOptionsChange({
+      ...cOptions,
+      trimEnd: duration,
+    })
   }
 
   const handleRatioChange = (value: boolean) => {
@@ -656,6 +680,7 @@ export function VideoSettings({
                 </label>
               </div>
             {trimVideo && (
+              <>
               <div className="grid grid-cols-2 gap-2">
                 <div>
                   <Label className="text-base font-bold" htmlFor="trimStart">
@@ -663,12 +688,8 @@ export function VideoSettings({
                   </Label>
                   <Input
                     disabled={isDisabled}
-                    onChange={(e) =>
-                      onOptionsChange({
-                        ...cOptions,
-                        trimStart: e.target.value,
-                      })
-                    }
+                    onChange={(e) => handleTrimStartChange(e.target.value)}
+                    pattern="^\d+:[0-5]\d:[0-5]\d$"
                     value={cOptions.trimStart}
                     type="string"
                     id="trimStart"
@@ -680,18 +701,21 @@ export function VideoSettings({
                   </Label>
                   <Input
                     disabled={isDisabled}
-                    onChange={(e) =>
-                      onOptionsChange({
-                        ...cOptions,
-                        trimEnd: e.target.value,
-                      })
-                    }
+                    onChange={(e) => handleTrimEndChange(e.target.value)}
+                    pattern="^\d+:[0-5]\d:[0-5]\d$"
                     value={cOptions.trimEnd}
                     type="string"
                     id="trimEnd"
                   />
                 </div>
-              </div>)}
+              </div>
+              {trimInputError() && (
+                <div>
+                  {trimInputError()}
+                </div>
+              )}
+              </>
+            )}
             </div>
             <div className="flex flex-col gap-2">
               <h3 className="text-base font-bold">Audio</h3>

--- a/features/compression/components/video-settings.tsx
+++ b/features/compression/components/video-settings.tsx
@@ -184,6 +184,12 @@ export function VideoSettings({
     }
   }, [trimVideo, videoMetadata]);
 
+  useEffect(() => {
+    if (activeTab !== "super") {
+      setTrimVideo(false);
+    }
+  }, [activeTab]);
+
   const handleQualityChange = (value: number) => {
     onOptionsChange({
       ...cOptions,

--- a/features/compression/compressor.tsx
+++ b/features/compression/compressor.tsx
@@ -61,6 +61,7 @@ export default function Compressor() {
     generateVideoPreview,
     progress,
     transcode,
+    abort
   } = useFfmpeg();
 
   const handleTranscode = async () => {
@@ -289,6 +290,14 @@ export default function Compressor() {
                         <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
                       )}
                       {isGeneratingPreview ? "Processing" : "Generate Preview"}
+                    </Button>
+                  )}
+                  {isTranscoding && (
+                    <Button
+                      className="flex-0"
+                      onClick={abort}
+                    >
+                      x
                     </Button>
                   )}
                 </div>

--- a/features/compression/hooks/use-ffmpeg.tsx
+++ b/features/compression/hooks/use-ffmpeg.tsx
@@ -264,7 +264,6 @@ export const useFfmpeg = () => {
           dispatch({ type: "ABORT" });
           return null;
         }
-        console.log(error);
         dispatch({
           type: "PREVIEW_FAILURE",
           error: (error as Error).message,

--- a/features/compression/hooks/use-ffmpeg.tsx
+++ b/features/compression/hooks/use-ffmpeg.tsx
@@ -150,7 +150,7 @@ export const useFfmpeg = () => {
       dispatch({ type: "LOAD_SUCCESS" });
 
       ffmpegService.ffmpeg.on("progress", (progress) => {
-        dispatch({ type: "TRANSCODE_PROGRESS", progress: progress.progress });
+        dispatch({ type: "TRANSCODE_PROGRESS", progress: progress.progress / ffmpegService.getDurationRatio() });
       });
 
       ffmpegService.ffmpeg.on("log", (log) => {

--- a/features/compression/lib/seconds-to-timestamp.ts
+++ b/features/compression/lib/seconds-to-timestamp.ts
@@ -1,5 +1,9 @@
 export function secondsToTimestamp(seconds: number): string {
   const date = new Date(0);
   date.setSeconds(seconds);
-  return date.toISOString().slice(11, 19);
+  try {
+    return date.toISOString().slice(11, 19);
+  } catch (e) {
+    return "00:00:00";
+  }
 }

--- a/features/compression/lib/timestamp-to-seconds.ts
+++ b/features/compression/lib/timestamp-to-seconds.ts
@@ -1,0 +1,30 @@
+/**
+ * Converts a timestamp string in the format "HH:MM:SS", "MM:SS", or "SS" to seconds.
+ * @param timestamp - The timestamp string to convert
+ * @returns The total number of seconds represented by the timestamp
+ * @throws Error if the timestamp format is invalid
+ * @example
+ * // returns 3661
+ * timestampToSeconds("01:01:01");
+ * // returns 61
+ * timestampToSeconds("01:01");
+ * // returns 1
+ * timestampToSeconds("01");
+ */
+export const timestampToSeconds = (timestamp: string): number => {
+    const parts = timestamp.split(":").map(Number);
+    let seconds = 0;
+    
+    if (parts.length === 3) {
+        seconds += parts[0] * 3600; // hours
+        seconds += parts[1] * 60;   // minutes
+        seconds += parts[2];        // seconds
+    } else if (parts.length === 2) {
+        seconds += parts[0] * 60;   // minutes
+        seconds += parts[1];        // seconds
+    } else if (parts.length === 1) {
+        seconds += parts[0];        // seconds
+    }
+    
+    return seconds;
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,4 @@
   for = "/*"
   [headers.values]
   Cross-Origin-Embedder-Policy = "require-corp"
+  Cross-Origin-Opener-Policy = "same-origin"

--- a/services/ffmpeg.ts
+++ b/services/ffmpeg.ts
@@ -326,7 +326,7 @@ export class FFmpegService {
       this.ffmpeg.exec(
         [
           "-ss",
-          "0",
+          options?.trimStart ?? "0",
           "-i",
           `${inputDir}/${file.name}`,
           "-t",


### PR DESCRIPTION
Closes #6 

Adds 
- [x] ability to specify a start and end time to trim video to

Known Issues 
- [x] ~~preview videos are not synced due to keyframe issues~~ (firefox only)

To-do
- [x] ffmpeg progress bar does not account for trim so need to multiply progress by trim ratio?
- [x] validate trim inputs
- [x] clean up trim options when switching from "super" tab